### PR TITLE
fix: 【delay刷新】导致的状态错误

### DIFF
--- a/refresh-layout/src/main/java/com/scwang/smartrefresh/layout/SmartRefreshLayout.java
+++ b/refresh-layout/src/main/java/com/scwang/smartrefresh/layout/SmartRefreshLayout.java
@@ -181,6 +181,7 @@ public class SmartRefreshLayout extends ViewGroup implements RefreshLayout, Nest
     protected Handler mHandler;
     protected RefreshKernel mKernel = new RefreshKernelImpl();
 //    protected List<DelayedRunnable> mListDelayedRunnable;
+    protected Runnable mStartRefreshDelayRunnable = null;
 
     /**
      * 【主要状态】
@@ -2847,6 +2848,10 @@ public class SmartRefreshLayout extends ViewGroup implements RefreshLayout, Nest
      */
     @Override
     public RefreshLayout finishRefresh(int delayed, final boolean success, final Boolean noMoreData) {
+        if (mStartRefreshDelayRunnable != null) {
+            mHandler.removeCallbacks(mStartRefreshDelayRunnable);
+        }
+
         final int more = delayed >> 16;
         int delay = delayed << 16 >> 16;
         Runnable runnable = new Runnable() {
@@ -3209,6 +3214,7 @@ public class SmartRefreshLayout extends ViewGroup implements RefreshLayout, Nest
             setViceState(RefreshState.Refreshing);
             if (delayed > 0) {
                 mHandler.postDelayed(runnable, delayed);
+                mStartRefreshDelayRunnable = runnable;
             } else {
                 runnable.run();
             }


### PR DESCRIPTION
原因：finishRefresh 先于  autoRefresh 执行时，状态一致处于正在刷新

复现场景：
1. Fragment的onViewCreated()调用SmartRefreshLayout#autoRefreshAnimationOnly()
2. Fragment的onResume()调用异步执行耗时操作，拿到数据后调用SmartRefreshLayout#finishRefresh()
3. 当2中的耗时操作很短，会发现即使调用过finishRefresh()，SmartRefreshLayout还是切换到刷新状态了