### PR TITLE
时区修改后需要及时更新下拉刷新的时间否则出现下拉刷新的时间与系统时间不一致问题

### DIFF
--- a/refresh-header-classics/src/main/java/com/scwang/smart/refresh/header/ClassicsHeader.java
+++ b/refresh-header-classics/src/main/java/com/scwang/smart/refresh/header/ClassicsHeader.java
@@ -29,9 +29,11 @@ import com.scwang.smart.refresh.layout.util.SmartUtil;
 
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
+import java.util.TimeZone;
 
 import static android.view.ViewGroup.LayoutParams.WRAP_CONTENT;
 
@@ -291,6 +293,7 @@ public class ClassicsHeader extends ClassicsAbstract<ClassicsHeader> implements 
     public ClassicsHeader setLastUpdateTime(Date time) {
         final View thisView = this;
         mLastTime = time;
+        mLastUpdateFormat.setCalendar(Calendar.getInstance(TimeZone.getDefault(),  Locale.getDefault()));
         mLastUpdateText.setText(mLastUpdateFormat.format(time));
         if (mShared != null && !thisView.isInEditMode()) {
             mShared.edit().putLong(KEY_LAST_UPDATE_TIME, time.getTime()).apply();


### PR DESCRIPTION
如果修改了时区后ClassicsHeader没有重新创建,则下拉刷新一直会沿用老的时区,导致应用下拉刷新的时间与系统时间不一致